### PR TITLE
Websubmit: fixes and improvements

### DIFF
--- a/modules/websubmit/lib/functions/Create_Modify_Interface.py
+++ b/modules/websubmit/lib/functions/Create_Modify_Interface.py
@@ -232,7 +232,7 @@ def Create_Modify_Interface(parameters, curdir, form, user_info=None):
         t = t + "<FONT color=\"darkblue\">\n"
         res = run_sql("SELECT modifytext FROM sbmFIELDDESC WHERE  name=%s", (field,))
         if len(res)>0:
-            t = t + "<small>%s</small> </FONT>\n" % res[0][0]
+            t = t + "<small>%s</small> </FONT>\n" % (res[0][0] is None and ' ' or res[0][0],)
         # retrieve the marc code associated with the field
         res = run_sql("SELECT marccode FROM sbmFIELDDESC WHERE name=%s", (field,))
         if len(res) > 0:

--- a/modules/websubmit/lib/websubmit_engine.py
+++ b/modules/websubmit/lib/websubmit_engine.py
@@ -496,6 +496,7 @@ def interface(req,
 
     for field_instance in form_fields:
         full_field = {}
+
         ## Retrieve the field's description:
         element_descr = get_element_description(field_instance[3])
         try:
@@ -538,18 +539,26 @@ def interface(req,
             try:
                 co = compile (full_field ['htmlcode'].replace("\r\n","\n"), "<string>", "exec")
                 the_globals['text'] = ''
+                the_globals['custom_level'] = None
                 exec co in the_globals
                 text = the_globals['text']
+                # Also get the custom_level if it's define in the element description
+                custom_level = the_globals.get('custom_level')
+                # Make sure custom_level has an appropriate value or default to 'O'
+                if custom_level not in ('M', 'O', None):
+                    custom_level = 'O'
             except:
                 register_exception(req=req, alert_admin=True, prefix="Error in evaluating response element %s with globals %s" % (pprint.pformat(full_field), pprint.pformat(the_globals)))
                 raise
         else:
             text = websubmit_templates.tmpl_submit_field (ln = ln, field = full_field)
+            # Provide a default value for the custom_level
+            custom_level = None
 
         # we now determine the exact type of the created field
         if full_field['type'] not in [ 'D','R']:
             field.append(full_field['name'])
-            level.append(field_instance[5])
+            level.append(custom_level is None and field_instance[5] or custom_level)
             fullDesc.append(field_instance[4])
             txt.append(field_instance[6])
             check.append(field_instance[7])
@@ -593,7 +602,7 @@ def interface(req,
             upload.append(0)
             # field.append(value) - initial version, not working with JS, taking a submitted value
             field.append(field_instance[3])
-            level.append(field_instance[5])
+            level.append(custom_level is None and field_instance[5] or custom_level)
             txt.append(field_instance[6])
             fullDesc.append(field_instance[4])
             check.append(field_instance[7])

--- a/modules/websubmit/lib/websubmit_templates.py
+++ b/modules/websubmit/lib/websubmit_templates.py
@@ -678,7 +678,7 @@ class Template:
             out += "  el = document.forms[0].elements['%s'];\n" % fieldname
             # If the field must be checked we call the checking function
             if check[i] != "":
-                out += """if (%(check)s(el.value) == 0) {
+                out += """if (el !== undefined && %(check)s(el.value) == 0) {
                             el.focus();
                             return 0;
                           } """ % {


### PR DESCRIPTION
3 commits:

WebSubmit: more robust javascript check
- Before running a custom JavaScript function on an element, check if the element is not undefined.

WebSubmit: print white space instead of None
- Avoids printing "None" (by passing None to string formatting). Instead, print a single white space.

WebSubmit: support for elements' custom_level
- Adds support for optionally setting a custom_level ('M' for mandatory or 'O' for optional) for each element through the element description, overriding the default level. Useful for dynamically produced elements.
