### PR TITLE
BibDocFile: escape file URLs in /files tab

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile_templates.py
+++ b/modules/bibdocfile/lib/bibdocfile_templates.py
@@ -366,7 +366,7 @@ class Template:
             CFG_SITE_URL,
             CFG_SITE_RECORD,
             recid,
-            '%s%s' % (cgi.escape(name, True), superformat))
+            '%s%s' % (cgi.escape(urllib.quote(name), True), superformat))
 
         urlargd = {'version' : version}
         if subformat:


### PR DESCRIPTION
Co-authored by: Jerome Caffaro jerome.caffaro@cern.ch
Signed-off-by: Ludmila Marian ludmila.marian@gmail.com
