### PR TITLE
WebSubmit: rotate created icons according to EXIF

### DIFF
--- a/modules/websubmit/lib/websubmit_icon_creator.py
+++ b/modules/websubmit/lib/websubmit_icon_creator.py
@@ -293,7 +293,7 @@ def build_icon(path_workingdir,
         delay_info = "-delay %s" % escape_shell_arg(str(multipage_icon_delay))
 
     ## Command for icon creation:
-    cmd_create_icon = "%(convert)s -colorspace rgb -scale %(scale)s %(delay)s " \
+    cmd_create_icon = "%(convert)s -colorspace rgb -auto-orient -scale %(scale)s %(delay)s " \
                       "%(source-file-path)s %(icon-file-path)s 2>/dev/null" \
                       % { 'convert'          : CFG_PATH_CONVERT,
                           'scale'            : \


### PR DESCRIPTION
- When creating icons, rotate the created icons according to
  the Exif "Orientation" metadata of the original photo.
  Closes #1516.

Signed-off-by: Jerome Caffaro jerome.caffaro@cern.ch
Reviewed-by: Ludmila Marian ludmila.marian@gmail.com
