### PR TITLE
WebSearch: add 'anyfield' key to CFG_WEBSEARCH_SYNONYM_KBRS

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -597,7 +597,8 @@ CFG_WEBSEARCH_WILDCARD_LIMIT = 50000
 ## be used for which index in order to provide runtime synonym lookup
 ## of user-supplied terms, and what massaging function should be used
 ## upon search pattern before performing the KB lookup.  (Can be one
-## of `exact', 'leading_to_comma', `leading_to_number'.)
+## of `exact', 'leading_to_comma', `leading_to_number'.) Use
+## 'anyfield' key to match when field is not specifically set.
 CFG_WEBSEARCH_SYNONYM_KBRS = {
     'journal': ['SEARCH-SYNONYM-JOURNAL', 'leading_to_number'],
     }

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2320,13 +2320,13 @@ def search_unit(p, f=None, m=None, wl=0, ignore_synonyms=None):
 
     ## eventually look up runtime synonyms:
     hitset_synonyms = intbitset()
-    if f in CFG_WEBSEARCH_SYNONYM_KBRS:
+    if CFG_WEBSEARCH_SYNONYM_KBRS.has_key(f or 'anyfield'):
         if ignore_synonyms is None:
             ignore_synonyms = []
         ignore_synonyms.append(p)
         for p_synonym in get_synonym_terms(p,
-                             CFG_WEBSEARCH_SYNONYM_KBRS[f][0],
-                             CFG_WEBSEARCH_SYNONYM_KBRS[f][1]):
+                             CFG_WEBSEARCH_SYNONYM_KBRS[f or 'anyfield'][0],
+                             CFG_WEBSEARCH_SYNONYM_KBRS[f or 'anyfield'][1]):
             if p_synonym != p and \
                    not p_synonym in ignore_synonyms:
                 hitset_synonyms |= search_unit(p_synonym, f, m, wl,


### PR DESCRIPTION
- CFG_WEBSEARCH_SYNONYM_KBRS can use the keyword 'anyfield' to
  match a given knowledge base when searching without a particular
  field. (closes #1493)

Signed-off-by: Jerome Caffaro jerome.caffaro@cern.ch
Reviewed-by: Ludmila Marian ludmila.marian@cern.ch
