### PR TITLE
WebSearch: resolve (internal) DOIs

### DIFF
--- a/modules/websearch/lib/websearch_regression_tests.py
+++ b/modules/websearch/lib/websearch_regression_tests.py
@@ -4979,7 +4979,6 @@ class WebSearchCustomCollectionBoxesName(InvenioTestCase):
                          test_web_page_content(CFG_SITE_URL + '/collection/CERN%20Divisions?ln=af',
                                                expected_text='Browse by division:'))
 
-
 class WebSearchDetailedRecordTabsTest(InvenioTestCase):
     def test_detailed_record(self):
         """websearch - check detailed record main tab"""
@@ -5049,6 +5048,39 @@ class WebSearchDetailedRecordTabsTest(InvenioTestCase):
                                                    expected_text='Linkbacks',
                                                    unexpected_text='The server encountered an error'))
 
+class WebSearchResolveDOITest(InvenioTestCase):
+    """Checks that we can resolve DOIs """
+
+    def test_resolve_existing_doi(self):
+        """websearch - check resolution of a DOI for an existing record"""
+        error_messages = []
+        error_messages.extend(test_web_page_content(CFG_SITE_URL + "/doi/10.4028/www.scientific.net/MSF.638-642.1098",
+                                                    expected_text = ['Influence of processing parameters on the manufacturing of anode-supported solid oxide fuel cells by different wet chemical routes'],
+                                                    unexpected_text = ['404 Not Found', 'could not be resolved']))
+
+        error_messages.extend(test_web_page_content(CFG_SITE_URL + "/doi/10.1063/1.2737136",
+                                                    expected_text = ['Epitaxially stabilized growth of orthorhombic LuScO3 thin films'],
+                                                    unexpected_text = ['404 Not Found', 'could not be resolved']))
+        if error_messages:
+            self.fail(merge_error_messages(error_messages))
+
+    def test_resolve_non_existing_doi(self):
+        """websearch - check resolution of a non-existing DOI"""
+        error_messages = []
+        error_messages.extend(test_web_page_content(CFG_SITE_URL + "/doi/foobar",
+                                                    expected_text = ['could not be resolved', 'foobar'],
+                                                    unexpected_text = ['404 Not Found']))
+        if error_messages:
+            self.fail(merge_error_messages(error_messages))
+
+    def test_resolve_non_doi(self):
+        """websearch - check resolution of a non-DOI value living in 0247_a (without 0247__2:DOI)"""
+        error_messages = []
+        error_messages.extend(test_web_page_content(CFG_SITE_URL + "/doi/0255-5476",
+                                                    expected_text = ['could not be resolved', '0255-5476'],
+                                                    unexpected_text = ['404 Not Found']))
+        if error_messages:
+            self.fail(merge_error_messages(error_messages))
 
 TEST_SUITE = make_test_suite(WebSearchWebPagesAvailabilityTest,
                              WebSearchTestSearch,
@@ -5103,8 +5135,8 @@ TEST_SUITE = make_test_suite(WebSearchWebPagesAvailabilityTest,
                              WebSearchCJKTokenizedSearchTest,
                              WebSearchItemCountQueryTest,
                              WebSearchCustomCollectionBoxesName,
-                             WebSearchDetailedRecordTabsTest,)
-
+                             WebSearchDetailedRecordTabsTest,
+                             WebSearchResolveDOITest)
 
 if __name__ == "__main__":
     run_test_suite(TEST_SUITE, warn_user=True)

--- a/modules/websearch/lib/websearch_templates.py
+++ b/modules/websearch/lib/websearch_templates.py
@@ -72,6 +72,7 @@ from invenio.config import \
 from invenio.search_engine_config import CFG_WEBSEARCH_RESULTS_OVERVIEW_MAX_COLLS_TO_PRINT
 from invenio.websearch_services import \
      CFG_WEBSEARCH_MAX_SEARCH_COLL_RESULTS_TO_PRINT
+from invenio.bibformat import format_record
 
 from invenio.dbquery import run_sql
 from invenio.messages import gettext_set_language
@@ -4889,4 +4890,25 @@ class Template:
             else:
                 out += '<format name="%s" type="%s" />\n' % (xml_escape(format_name), xml_escape(format_type))
         out += "</formats>"
+        return out
+
+    def tmpl_multiple_dois_found_page(self, doi, recids, ln=CFG_SITE_LANG, verbose=0):
+        """
+        Page displayed when multiple records would match a DOIs
+
+        @param doi: DOI that has multiple matching records
+        @param recids: record IDs matched by given C{DOI}
+        @param ln: language
+        """
+        _ = gettext_set_language(ln)
+        out = ""
+        out += _('For some unknown reason multiple records matching the specified DOI "%s" have been found.') % cgi.escape(doi)
+        out += '<br/>' + _('The system administrators have been alerted.')
+        out += '<br/>' + _('In the meantime you can pick one of the retrieved candidates:')
+        out += '<br/><ul>' + '\n'.join(['<li>' + format_record(recid, of='hb', verbose=verbose) + '<br/>' + \
+                                        create_html_link(CFG_SITE_URL + '/' + CFG_SITE_RECORD + '/' + str(recid), \
+                                                         {}, _("Detailed record"), {'class': 'moreinfo'}) + \
+                                     '</li>' \
+                                     for recid in recids]) + \
+                     '</ul>'
         return out


### PR DESCRIPTION
- When accessing "CFG_SITE_URL/doi/foo/bar", try to resolve 'foo/bar'
  as DOI and return corresponding record (0247__a:'foo/bar'). In this
  initial release the 'source' field (0247__2:doi) is not considered.
  Closes #1322.

Signed-off-by: Jerome Caffaro jerome.caffaro@cern.ch
Reviewed-by: Ludmila Marian ludmila.marian@gmail.com
