### PR TITLE
WebSession: Python-2.4 combatibility issue fix

### DIFF
--- a/modules/websession/lib/websession_templates.py
+++ b/modules/websession/lib/websession_templates.py
@@ -137,6 +137,11 @@ class Template:
             out += """
                     <table>
                     """
+
+            # In Python 2.4 tuples don't have the index attribute.
+            # We therefore need to convert the keys_info tuple to a list.
+            keys_info = list(keys_info)
+
             for key_info in keys_info:
                 out += """
                         <tr><td>%(key_description)s</td>


### PR DESCRIPTION
- In Python-2.4 tuples don't have the index attribute. Converting a tuple to a
  list will provide that attribute.

Signed-off-by: Nikolaos Kasioumis nikolaos.kasioumis@cern.ch
Reviewed-by: Tibor Simko tibor.simko@cern.ch
