### PR TITLE
WebSearch: new parsing of unbalanced phrase queries

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -911,6 +911,12 @@ def create_basic_search_units(req, p, f, m=None, of='hb'):
                     if of.startswith("h"):
                         write_warning("Ignoring empty <em>%s</em> search term." % fi, "Warning", req=req)
                 del opfts[i]
+            # Handles phrases that lack ending double quote
+            if (pi.startswith('"') and not pi.endswith('"')) or (not pi.startswith('"') and pi.endswith('"')):
+                oi, pi, fi, m = opfts[i]
+                opfts[i] = [oi, pi.replace('"', ''), fi, m]
+                if of.startswith("h"):
+                    write_warning("Ignoring incorrect phrase double quotation marks.", "Warning", req=req)
         except:
             pass
 

--- a/modules/websearch/lib/search_engine_unit_tests.py
+++ b/modules/websearch/lib/search_engine_unit_tests.py
@@ -116,7 +116,22 @@ class TestQueryParser(InvenioTestCase):
     def test_parsing_exact_phrase_query_unbalanced(self):
         "search engine - parsing unbalanced exact phrase"
         self._check('"the word', 'title', None,
-                    [['+', '"the', 'title', 'w'],
+                    [['+', 'the', 'title', 'w'],
+                     ['+', 'word', 'title', 'w']])
+        self._check('the" word', 'title', None,
+                    [['+', 'the', 'title', 'w'],
+                     ['+', 'word', 'title', 'w']])
+        self._check('"the"one" word', 'title', None,
+                    [['+', 'theone', 'title', 'a'],
+                     ['+', 'word', 'title', 'w']])
+        self._check('"theone" word', 'title', None,
+                    [['+', 'theone', 'title', 'a'],
+                     ['+', 'word', 'title', 'w']])
+        self._check('"t\'heone" word', 'title', None,
+                    [['+', "t'heone", 'title', 'a'],
+                     ['+', 'word', 'title', 'w']])
+        self._check('"t\"heone" word', 'title', None,
+                    [['+', 'theone', 'title', 'a'],
                      ['+', 'word', 'title', 'w']])
 
     def test_parsing_exact_phrase_query_in_any_field(self):


### PR DESCRIPTION
- Removes unbalanced double quotation marks.

Signed-off-by: Patrick Glauner patrick.oliver.glauner@cern.ch
