### PR TITLE
Miscutils: fix for send_email error on DEV site

### DIFF
--- a/modules/miscutil/lib/mailutils.py
+++ b/modules/miscutil/lib/mailutils.py
@@ -221,7 +221,7 @@ This message would have been sent to the following recipients:
 %s
 --------------------------------------------------------------
 %s""" % (toaddr, content)
-        toaddr = CFG_SITE_ADMIN_EMAIL
+        toaddr = [CFG_SITE_ADMIN_EMAIL]
         usebcc = False
     body = forge_email(fromaddr, toaddr, subject, content, html_content,
                        html_images, usebcc, header, footer, html_header,


### PR DESCRIPTION
- For the DEV site send_email function was failing while trying to
  concatenate list and string (because the CFG_SITE_ADMIN_EMAIL
  was not a list).
