### PR TITLE
oaiharvest: conversion argument name confusion

### DIFF
--- a/modules/miscutil/lib/upgrades/invenio_2014_06_02_oaiHARVEST_arguments_cfg_namechange.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_06_02_oaiHARVEST_arguments_cfg_namechange.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from invenio.dbquery import (run_sql,
+                             serialize_via_marshal,
+                             deserialize_via_marshal)
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    return "Change of oaiHARVEST.arguments c_cfg-file to c_stylesheet"
+
+
+def do_upgrade():
+    rows_to_change = run_sql("SELECT id, arguments FROM oaiHARVEST", with_dict=True)
+    # Move away from old columns
+    for row in rows_to_change:
+        if row['arguments']:
+            arguments = deserialize_via_marshal(row['arguments'])
+            if "c_cfg-file" in arguments:
+                arguments['c_stylesheet'] = arguments['c_cfg-file']
+                del arguments['c_cfg-file']
+        run_sql("UPDATE oaiHARVEST set arguments=%s WHERE id=%s", (serialize_via_marshal(arguments), row['id']))
+
+
+def estimate():
+    """  Estimate running time of upgrade in seconds (optional). """
+    count_rows = run_sql("SELECT COUNT(*) FROM oaiHARVEST")[0][0]
+    return count_rows / 20
+
+
+def pre_upgrade():
+    pass
+
+
+def post_upgrade():
+    pass

--- a/modules/oaiharvest/lib/oai_harvest_web_tests.py
+++ b/modules/oaiharvest/lib/oai_harvest_web_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ## This file is part of Invenio.
-## Copyright (C) 2011, 2012 CERN.
+## Copyright (C) 2011, 2012, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -20,9 +20,9 @@
 """OaiHarvest module web tests."""
 
 from invenio.config import CFG_SITE_SECURE_URL
-from invenio.testutils import make_test_suite, \
-                              run_test_suite, \
-                              InvenioWebTestCase
+from invenio.testutils import (make_test_suite,
+                               run_test_suite,
+                               InvenioWebTestCase)
 
 
 class InvenioOaiHarvestWebTest(InvenioWebTestCase):
@@ -50,8 +50,8 @@ class InvenioOaiHarvestWebTest(InvenioWebTestCase):
         self.browser.find_element_by_id(id="post_input_c0").click()
         self.find_element_by_xpath_with_timeout("//input[@value='Add OAI Source']", timeout=60)
         self.browser.find_element_by_xpath("//input[@value='Add OAI Source']").click()
-        self.page_source_test(expected_text="The field 'cfg-file' is an required argument when choosing 'convert (c)' post-process.")
-        self.fill_textbox(textbox_name="c_cfg-file", text="oaimarc2marcxml.xsl")
+        self.page_source_test(expected_text="The field 'stylesheet' is an required argument when choosing 'convert (c)' post-process.")
+        self.fill_textbox(textbox_name="c_stylesheet", text="oaimarc2marcxml.xsl")
         self.find_element_by_xpath_with_timeout("//input[@value='Add OAI Source']")
         self.browser.find_element_by_xpath("//input[@value='Add OAI Source']").click()
         self.find_element_by_link_text_with_timeout("Go back to the OAI sources overview")


### PR DESCRIPTION
- Adds the missing upgrade script for changes done to OAI harvest
  source arguments in f9271a0 that could cause name problems during
  harvesting when upgrading an existing installation.
- Amends the web-tests to look for the proper new name.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
