### PR TITLE
WebComment: general comment format improvements

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -225,7 +225,7 @@ CFG_ERRORLIB_RESET_EXCEPTION_NOTIFICATION_COUNTER_AFTER = 14400
 
 ## CFG_ERRORLIB_SENTRY_URI -- optionally, if you use Sentry for logging.
 ## Sentry notifies you when your users experience errors.
-## Enables logging of exceptions in invenio to given Sentry server. 
+## Enables logging of exceptions in invenio to given Sentry server.
 CFG_ERRORLIB_SENTRY_URI =
 
 ## CFG_CERN_SITE -- do we want to enable CERN-specific code?
@@ -1467,6 +1467,15 @@ CFG_WEBCOMMENT_MAX_ATTACHED_FILES = 5
 # parent's comment). Use -1 for no limit, 0 for unthreaded (flat)
 # discussions.
 CFG_WEBCOMMENT_MAX_COMMENT_THREAD_DEPTH = 1
+
+# CFG_WEBCOMMENT_ENABLE_HTML_EMAILS -- if True, emails will also contain
+# HTML content, in addition to the plaintext version.
+CFG_WEBCOMMENT_ENABLE_HTML_EMAILS = True
+
+# CFG_WEBCOMMENT_ENABLE_MARKDOWN_TEXT_RENDERING -- if True, and when
+# CFG_WEBCOMMENT_USE_RICH_TEXT_EDITOR is False, plain text will be rendered
+# as Markdown <http://daringfireball.net/projects/markdown/>.
+CFG_WEBCOMMENT_ENABLE_MARKDOWN_TEXT_RENDERING = True
 
 ##################################
 ## Part 11: BibSched parameters ##

--- a/modules/miscutil/lib/htmlutils.py
+++ b/modules/miscutil/lib/htmlutils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -595,6 +595,51 @@ def get_html_text_editor(name, id=None, content='', textual_content=None, width=
              evt.editor.resetDirty();
              } );
             /* End workaround */
+
+            // Catch any key being pressed
+            evt.editor.on('key', function(e) {
+
+                /*
+                Adding inline text can be difficult due to problebatic
+                blockquote breaking. The code below will catch the "Enter"
+                key being pressed and will try to break the blockquotes.
+                The following code has partially been taken from:
+                <http://dev.ckeditor.com/browser/CKEditor/trunk/_source/plugins/enterkey/plugin.js>
+                */
+                if ( e.data.keyCode == 13 ) {
+
+                    // The following will break all blockquotes, one Enter at a time
+                    var selection = oEditor.getSelection();
+                    var element = selection.getStartElement();
+                    var parent = element.getParent();
+                    var range_split_block = true;
+
+                    if ( element.is("blockquote") && parent.is("body") ) {
+                        if ( element.getText().trim() == "" ) {
+                            element.remove();
+                            range_split_block = false;
+                            // Adding an empty paragraph seems to make it smoother
+                            CKEDITOR.instances.msg.insertHtml("<p></p>");
+                        }
+                    }
+
+                    if ( range_split_block == true ) {
+                        var ranges = selection.getRanges(true);
+                        for ( var i = ranges.length - 1 ; i > 0 ; i-- ) {
+                            ranges[i].deleteContents();
+                        }
+                        var range = ranges[0];
+                        range.splitBlock("blockquote");
+                        if ( ! ( element.is("p") && parent.is("body") ) ) {
+                            // Adding an empty paragraph seems to make it smoother
+                            CKEDITOR.instances.msg.insertHtml("<p></p>");
+                        }
+                    }
+
+                }
+
+            });
+
           })
 
         //]]></script>

--- a/modules/miscutil/lib/upgrades/invenio_2014_07_30_webcomment_new_column_body_format.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_07_30_webcomment_new_column_body_format.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from invenio.dbquery import run_sql
+from invenio.webcomment_config import CFG_WEBCOMMENT_BODY_FORMATS
+from invenio.webmessage_mailutils import email_quoted_txt2html
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    return "New column 'body_format' for WebComment's cmtRECORDCOMMENT."
+
+
+def do_upgrade():
+    # First, insert the new column in the table.
+    run_sql("""ALTER TABLE  cmtRECORDCOMMENT
+               ADD COLUMN   body_format VARCHAR(10) NOT NULL DEFAULT %s
+               AFTER        body;""",
+            (CFG_WEBCOMMENT_BODY_FORMATS["HTML"],))
+
+    number_of_comments = run_sql("""SELECT  COUNT(id)
+                                    FROM    cmtRECORDCOMMENT""")[0][0]
+
+    if number_of_comments > 0:
+
+        # NOTE: Consider that the bigger the number of comments,
+        #       the more powerful the server. Keep the number of
+        #       batches fixed and scale the batch size instead.
+        number_of_select_batches = 100
+
+        select_batch_size = \
+            number_of_comments >= (number_of_select_batches * number_of_select_batches) and \
+            number_of_comments / number_of_select_batches or \
+            number_of_comments
+
+        number_of_select_iterations = \
+            number_of_select_batches + \
+            (number_of_comments % select_batch_size and 1)
+
+        comments_select_query = """ SELECT  id,
+                                            body,
+                                            body_format
+                                    FROM    cmtRECORDCOMMENT
+                                    LIMIT   %s, %s"""
+
+        comments_update_query = """ UPDATE  cmtRECORDCOMMENT
+                                    SET     body = %s
+                                    WHERE   id = %s"""
+
+        for number_of_select_iteration in xrange(number_of_select_iterations):
+
+            comments = run_sql(
+                comments_select_query,
+                (number_of_select_iteration * select_batch_size,
+                 select_batch_size)
+            )
+
+            for (comment_id, comment_body, comment_body_format) in comments:
+
+                if comment_body_format == CFG_WEBCOMMENT_BODY_FORMATS["HTML"]:
+
+                    comment_body = email_quoted_txt2html(
+                        comment_body,
+                        indent_html=("<blockquote>", "</blockquote>")
+                    )
+
+                    run_sql(
+                        comments_update_query,
+                        (comment_body, comment_id)
+                    )
+
+
+def estimate():
+    # TODO: The estimated time needed depends on the size of the table.
+    #       Should we calculate this more accurately?
+    return 1
+
+
+def pre_upgrade():
+    pass
+
+
+def post_upgrade():
+    pass

--- a/modules/webcomment/lib/webcomment_config.py
+++ b/modules/webcomment/lib/webcomment_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -28,6 +28,24 @@ CFG_WEBCOMMENT_ACTION_CODE = {
     'ADD_REVIEW': 'R',
     'VOTE': 'V',
     'REPORT_ABUSE': 'A'
+}
+
+CFG_WEBCOMMENT_BODY_FORMATS = {
+    "HTML"     : "HTML",
+    "TEXT"     : "TXT",
+    "MARKDOWN" : "MD",
+}
+
+CFG_WEBCOMMENT_OUTPUT_FORMATS = {
+    "HTML" : {
+        "WEB"      : "WEB",
+        "EMAIL"    : "HTML_EMAIL",
+        "CKEDITOR" : "CKEDITOR",
+    },
+    "TEXT" : {
+        "EMAIL"    : "TEXT_EMAIL",
+        "TEXTAREA" : "TEXTAREA",
+    },
 }
 
 # Exceptions: errors

--- a/modules/webcomment/lib/webcommentadminlib.py
+++ b/modules/webcomment/lib/webcommentadminlib.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -131,7 +131,7 @@ def perform_request_delete(comID=-1, recID=-1, uid=-1, reviews="", ln=CFG_SITE_L
 
             if comment:
                 # Figure out if this is a review or a comment
-                c_star_score = 5
+                c_star_score = 6
                 if comment[c_star_score] > 0:
                     reviews = 1
                 else:
@@ -359,11 +359,12 @@ def query_get_comments(uid, cmtID, recID, reviews, ln, abuse=False, user_collect
     tuple (nickname, uid, date_creation, body, nb_votes_yes, nb_votes_total, star_score, title, id, status)
     """
     qdict = {'id': 0, 'id_bibrec': 1, 'uid': 2, 'date_creation': 3, 'body': 4,
-    'status': 5, 'nb_abuse_reports': 6, 'nb_votes_yes': 7, 'nb_votes_total': 8,
-             'star_score': 9, 'title': 10, 'email': -2, 'nickname': -1}
+            'status': 5, 'nb_abuse_reports': 6, 'body_format': 7, 'nb_votes_yes': 8, 'nb_votes_total': 9,
+             'star_score': 10, 'title': 11, 'email': -2, 'nickname': -1}
     query = """SELECT c.id, c.id_bibrec, c.id_user,
                       DATE_FORMAT(c.date_creation, '%%Y-%%m-%%d %%H:%%i:%%S'), c.body,
                       c.status, c.nb_abuse_reports,
+                      c.body_format
                       %s
                       u.email, u.nickname
                FROM cmtRECORDCOMMENT c LEFT JOIN user u
@@ -403,14 +404,16 @@ def query_get_comments(uid, cmtID, recID, reviews, ln, abuse=False, user_collect
                                  qtuple[qdict['star_score']],
                                  qtuple[qdict['title']],
                                  qtuple[qdict['id']],
-                                 qtuple[qdict['status']])
+                                 qtuple[qdict['status']],
+                                 qtuple[qdict['body_format']])
             else:
                 comment_tuple = (nickname,
                                  qtuple[qdict['uid']],
                                  qtuple[qdict['date_creation']],
                                  qtuple[qdict['body']],
                                  qtuple[qdict['id']],
-                                 qtuple[qdict['status']])
+                                 qtuple[qdict['status']],
+                                 qtuple[qdict['body_format']])
             general_infos_tuple = (nickname,
                                    qtuple[qdict['uid']],
                                    qtuple[qdict['email']],

--- a/modules/webstyle/css/invenio.css
+++ b/modules/webstyle/css/invenio.css
@@ -2,7 +2,7 @@
 * -*- mode: text; coding: utf-8; -*-
 
    This file is part of Invenio.
-   Copyright (C) 2009, 2010, 2011, 2012, 2013 CERN.
+   Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 
    Invenio is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License as
@@ -3514,7 +3514,13 @@ a#advbox-toggle{
 }
 
 .webcomment_comment_box blockquote {
-	margin: 10px;
+  padding: 0px 10px 0px 10px;
+  margin: 0px 0px 0px 10px;
+  border-left: 2px solid #3366CC;
+}
+
+.webcomment_comment_body {
+  margin: 10px;
 }
 
 .webcomment_comment_options {

--- a/modules/webstyle/etc/invenio-ckeditor-config.js
+++ b/modules/webstyle/etc/invenio-ckeditor-config.js
@@ -1,3 +1,24 @@
+/*
+* -*- mode: text; coding: utf-8; -*-
+
+   This file is part of Invenio.
+   Copyright (C) 2011, 2012, 2013, 2014 CERN.
+
+   Invenio is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   Invenio is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Invenio; if not, write to the Free Software Foundation, Inc.,
+   59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+*/
+
 /*Define here the config of the CKEditor used in Invenio.
 
   Users/admin:
@@ -38,13 +59,7 @@ config.removePlugins = 'elementspath';
    simulate the the ".commentbox" CSS class in WebComment case. */
 config.contentsCss = ['/img/invenio.css', '/ckeditor/invenio-ckeditor-content.css'];
 
-/* Though not recommended, it is much better that users gets a
-   <br/> when pressing carriage return than a <p> element. Then
-   when a user replies to a webcomment without the CKeditor,
-   line breaks are nicely displayed.
-*/
-config.enterMode = CKEDITOR.ENTER_BR;
-
 /* Load our Scientific Characters panel */
 config.extraPlugins = 'scientificchar';
+
 }

--- a/modules/webstyle/etc/invenio-ckeditor-content.css
+++ b/modules/webstyle/etc/invenio-ckeditor-content.css
@@ -1,2 +1,26 @@
-blockquote {margin:0;padding:0;display:inline;}
-blockquote div, blockquote p{padding: 0 10px 0px 10px;border-left: 2px solid #36c;margin-left: 10px;display:inline;}
+/*
+* -*- mode: text; coding: utf-8; -*-
+
+   This file is part of Invenio.
+   Copyright (C) 2011, 2012, 2013, 2014 CERN.
+
+   Invenio is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   Invenio is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Invenio; if not, write to the Free Software Foundation, Inc.,
+   59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+*/
+
+blockquote {
+  padding: 0px 10px 0px 10px;
+  margin: 0px 0px 0px 10px;
+  border-left: 2px solid #3366CC;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ jinja2==2.7.2
 redis==2.9.0
 nydus==0.10.6
 Cerberus==0.5
+html2text==2014.7.3
+markdown2==2.2.1
+bleach==1.4


### PR DESCRIPTION
- Introduces the CFG_WEBCOMMENT_ENABLE_HTML_EMAILS config variable.
  When True, emails will also include HTML content.
- Introduces the body_format column for cmtRECORDCOMMENT that describes
  the format of the body of each comment ("HTML", "TEXT", etc.).
- Handles comments appropriately when storing and displaying them,
  according to their body format and desired output format. (closes #2064)

Co-Authored-By: Nikolaos Kasioumis nikolaos.kasioumis@cern.ch
Signed-off-by: Nikolaos Kasioumis nikolaos.kasioumis@cern.ch
