### PR TITLE
general: Elasticsearch logging with Lumberjack.

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -2533,6 +2533,39 @@ CFG_ARXIV_URL_PATTERN = http://export.arxiv.org/pdf/%sv%s.pdf
 ## e.g. CFG_REDIS_HOSTS = [{'db': 0, 'host': '127.0.0.1', 'port': 7001}]
 CFG_REDIS_HOSTS = {'default': [{'db': 0, 'host': '127.0.0.1', 'port': 6379}]}
 
+#################################
+## Elasticsearch Configuration ##
+#################################
+
+## CFG_ELASTICSEARCH_LOGGING -- Whether to use Elasticsearch logging or not
+CFG_ELASTICSEARCH_LOGGING = 0
+
+## CFG_ELASTICSEARCH_INDEX_PREFIX -- The prefix to be used for the
+## Elasticsearch indices.
+CFG_ELASTICSEARCH_INDEX_PREFIX = invenio-
+
+## CFG_ELASTICSEARCH_HOSTS -- The list of Elasticsearch hosts to connect to.
+## This is a list of dictionaries with connection information.
+CFG_ELASTICSEARCH_HOSTS = [{'host': '127.0.0.1', 'port': 9200}]
+
+## CFG_ELASTICSEARCH_SUFFIX_FORMAT -- The time format string to base the
+## suffixes for the Elasticsearch indices on.  E.g. "%Y.%m" for indices to be
+## called "invenio-2014.10" for example.
+CFG_ELASTICSEARCH_SUFFIX_FORMAT = %Y.%m
+
+## CFG_ELASTICSEARCH_MAX_QUEUE_LENGTH -- The maximum length the queue of events
+## is allowed to grow to before it is flushed to Elasticsearch.  If you don't
+## want to set a maximum, and rely entirely on the periodic flush instead, set
+## this to -1.
+CFG_ELASTICSEARCH_MAX_QUEUE_LENGTH = -1
+
+## CFG_ELASTICSEARCH_FLUSH_INTERVAL -- The time (in seconds) to wait between
+## flushes of the event queue to Elasticsearch.  If you want to disable
+## periodic flushing and instead rely on the max. queue length to trigger
+## flushes, set this to -1.
+CFG_ELASTICSEARCH_FLUSH_INTERVAL = 30
+
+
 ##########################
 ##  THAT's ALL, FOLKS!  ##
 ##########################

--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -118,13 +118,33 @@ from invenio.config import CFG_SITE_URL, \
     CFG_BIBDOCFILE_ENABLE_BIBDOCFSINFO_CACHE, \
     CFG_BIBDOCFILE_ADDITIONAL_KNOWN_MIMETYPES, \
     CFG_BIBDOCFILE_PREFERRED_MIMETYPES_MAPPING, \
-    CFG_BIBCATALOG_SYSTEM
+    CFG_BIBCATALOG_SYSTEM, \
+    CFG_ELASTICSEARCH_LOGGING
 from invenio.bibcatalog import BIBCATALOG_SYSTEM
 from invenio.bibdocfile_config import CFG_BIBDOCFILE_ICON_SUBFORMAT_RE, \
     CFG_BIBDOCFILE_DEFAULT_ICON_SUBFORMAT
 from invenio.pluginutils import PluginContainer
 
 import invenio.template
+
+if CFG_ELASTICSEARCH_LOGGING:
+    from invenio.elasticsearch_logging import register_schema
+    import logging
+
+    register_schema('events.downloads',
+        {
+            '_source': {'enabled': True},
+            'properties': {
+                'id_bibrec': {'type': 'integer'},
+                'id_bibdoc': {'type': 'integer'},
+                'file_version': {'type': 'short'},
+                'file_format': {'type': 'string'},
+                'id_user': {'type': 'integer'},
+                'client_host': {'type': 'ip'}
+            }
+        })
+
+    _DOWNLOAD_LOG = logging.getLogger('events.downloads')
 
 def _plugin_bldr(dummy, plugin_code):
     """Preparing the plugin dictionary structure"""
@@ -2854,12 +2874,23 @@ class BibDoc(object):
         docformat = docformat.upper()
         if not version:
             version = self.get_latest_version()
-        return run_sql("INSERT DELAYED INTO rnkDOWNLOADS "
-            "(id_bibrec,id_bibdoc,file_version,file_format,"
-            "id_user,client_host,download_time) VALUES "
-            "(%s,%s,%s,%s,%s,INET_ATON(%s),NOW())",
-            (recid, self.id, version, docformat,
-            userid, ip_address,))
+        if CFG_ELASTICSEARCH_LOGGING:
+            log_entry = {
+                'id_bibrec': recid,
+                'id_bibdoc': self.id,
+                'file_version': version,
+                'file_format': docformat,
+                'id_user': userid,
+                'client_host': ip_address
+            }
+            _DOWNLOAD_LOG.info(log_entry)
+        else:
+            return run_sql("INSERT DELAYED INTO rnkDOWNLOADS "
+                "(id_bibrec,id_bibdoc,file_version,file_format,"
+                "id_user,client_host,download_time) VALUES "
+                "(%s,%s,%s,%s,%s,INET_ATON(%s),NOW())",
+                (recid, self.id, version, docformat,
+                userid, ip_address,))
 
     def get_incoming_relations(self, rel_type=None):
         """Return all relations in which this BibDoc appears on target position

--- a/modules/bibrank/lib/bibrank_downloads_similarity.py
+++ b/modules/bibrank/lib/bibrank_downloads_similarity.py
@@ -22,10 +22,26 @@ __revision__ = \
 
 from invenio.config import \
      CFG_ACCESS_CONTROL_LEVEL_SITE, \
-     CFG_CERN_SITE
+     CFG_CERN_SITE, \
+     CFG_ELASTICSEARCH_LOGGING
 from invenio.dbquery import run_sql
 from invenio.bibrank_downloads_indexer import database_tuples_to_single_list
 from invenio.search_engine_utils import get_fieldvalues
+
+if CFG_ELASTICSEARCH_LOGGING:
+    from invenio.elasticsearch_logging import register_schema
+    import logging
+
+    register_schema('events.pageviews',
+        {
+            '_source': {'enabled': True},
+            'properties': {
+                'id_bibrec': {'type': 'integer'},
+                'id_user': {'type': 'integer'},
+                'client_host': {'type': 'ip'}
+            }
+        })
+    _PAGEVIEW_LOG = logging.getLogger('events.pageviews')
 
 def record_exists(recID):
     """Return 1 if record RECID exists.
@@ -55,10 +71,18 @@ def register_page_view_event(recid, uid, client_ip_address):
         # do not register access if we are in read-only access control
         # site mode:
         return []
-    return run_sql("INSERT DELAYED INTO rnkPAGEVIEWS " \
-                   " (id_bibrec,id_user,client_host,view_time) " \
-                   " VALUES (%s,%s,INET_ATON(%s),NOW())", \
-                   (recid, uid, client_ip_address))
+    if CFG_ELASTICSEARCH_LOGGING:
+        log_event = {
+            'id_bibrec': recid,
+            'id_user': uid,
+            'client_host': client_ip_address
+        }
+        _PAGEVIEW_LOG.info(log_event)
+    else:
+        return run_sql("INSERT DELAYED INTO rnkPAGEVIEWS " \
+                       " (id_bibrec,id_user,client_host,view_time) " \
+                       " VALUES (%s,%s,INET_ATON(%s),NOW())", \
+                       (recid, uid, client_ip_address))
 
 def calculate_reading_similarity_list(recid, type="pageviews"):
     """Calculate reading similarity data to use in reading similarity

--- a/modules/miscutil/lib/Makefile.am
+++ b/modules/miscutil/lib/Makefile.am
@@ -101,7 +101,8 @@ pylib_DATA = __init__.py \
              hepdatadisplayutils.py \
              hepdatautils_unit_tests.py \
              filedownloadutils.py \
-             filedownloadutils_unit_tests.py
+             filedownloadutils_unit_tests.py \
+             elasticsearch_logging.py
 
 jsdir=$(localstatedir)/www/js
 

--- a/modules/miscutil/lib/elasticsearch_logging.py
+++ b/modules/miscutil/lib/elasticsearch_logging.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+__revision__ = \
+   "$Id$"
+
+from invenio.config import \
+     CFG_ELASTICSEARCH_LOGGING, \
+     CFG_ELASTICSEARCH_INDEX_PREFIX, \
+     CFG_ELASTICSEARCH_HOSTS, \
+     CFG_ELASTICSEARCH_SUFFIX_FORMAT, \
+     CFG_ELASTICSEARCH_MAX_QUEUE_LENGTH, \
+     CFG_ELASTICSEARCH_FLUSH_INTERVAL
+
+if CFG_ELASTICSEARCH_LOGGING:
+    import lumberjack
+    import logging
+    import sys
+
+def initialise_lumberjack():
+    if not CFG_ELASTICSEARCH_LOGGING:
+        return None
+    config = lumberjack.get_default_config()
+    config['index_prefix'] = CFG_ELASTICSEARCH_INDEX_PREFIX
+
+    if CFG_ELASTICSEARCH_MAX_QUEUE_LENGTH == -1:
+        config['max_queue_length'] = None
+    else:
+        config['max_queue_length'] = CFG_ELASTICSEARCH_MAX_QUEUE_LENGTH
+
+    if CFG_ELASTICSEARCH_FLUSH_INTERVAL == -1:
+        config['interval'] = None
+    else:
+        config['interval'] = CFG_ELASTICSEARCH_FLUSH_INTERVAL
+
+    lj = lumberjack.Lumberjack(
+        hosts=CFG_ELASTICSEARCH_HOSTS,
+        config=config)
+
+    handler = lj.get_handler(suffix_format=CFG_ELASTICSEARCH_SUFFIX_FORMAT)
+    logging.getLogger('events').addHandler(handler)
+    logging.getLogger('events').setLevel(logging.INFO)
+
+    logging.getLogger('lumberjack').addHandler(
+        logging.StreamHandler(sys.stderr))
+    logging.getLogger('lumberjack').setLevel(logging.ERROR)
+
+    return lj
+
+LUMBERJACK = initialise_lumberjack()
+
+def register_schema(*args, **kwargs):
+    if not CFG_ELASTICSEARCH_LOGGING:
+        return None
+    return LUMBERJACK.register_schema(*args, **kwargs)

--- a/modules/miscutil/lib/inveniocfg.py
+++ b/modules/miscutil/lib/inveniocfg.py
@@ -188,7 +188,8 @@ Please, update your invenio-local.conf file accordingly.""" % (option_name, new_
                        'CFG_BIBSCHED_NON_CONCURRENT_TASKS',
                        'CFG_REDIS_HOSTS',
                        'CFG_BIBSCHED_INCOMPATIBLE_TASKS',
-                       'CFG_ICON_CREATION_FORMAT_MAPPINGS']:
+                       'CFG_ICON_CREATION_FORMAT_MAPPINGS',
+                       'CFG_ELASTICSEARCH_HOSTS']:
         try:
             option_value = option_value[1:-1]
             if option_name == "CFG_BIBEDIT_EXTEND_RECORD_WITH_COLLECTION_TEMPLATE" and option_value.strip().startswith("{"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ jinja2==2.7.2
 redis==2.9.0
 nydus==0.10.6
 Cerberus==0.5
+lumberjack==git+https://github.com/jmacmahon/lumberjack.git


### PR DESCRIPTION
- Added disabled-by-default config options for Elasticsearch logging.
- When Elasticsearch logging is configured, don't populate rnkPAGEVIEWS and
  rnkDOWNLOADS.

Signed-off-by: Joe MacMahon joe.macmahon@cern.ch
