### PR TITLE
Elasticsearch logging -- updated Lumberjack

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -130,21 +130,7 @@ from invenio.pluginutils import PluginContainer
 import invenio.template
 
 if CFG_ELASTICSEARCH_LOGGING:
-    from invenio.elasticsearch_logging import register_schema
     import logging
-
-    register_schema('events.downloads',
-        {
-            '_source': {'enabled': True},
-            'properties': {
-                'id_bibrec': {'type': 'integer'},
-                'id_bibdoc': {'type': 'integer'},
-                'file_version': {'type': 'short'},
-                'file_format': {'type': 'string'},
-                'id_user': {'type': 'integer'},
-                'client_host': {'type': 'ip'}
-            }
-        })
 
     _DOWNLOAD_LOG = logging.getLogger('events.downloads')
 

--- a/modules/bibrank/lib/bibrank_downloads_similarity.py
+++ b/modules/bibrank/lib/bibrank_downloads_similarity.py
@@ -29,18 +29,8 @@ from invenio.bibrank_downloads_indexer import database_tuples_to_single_list
 from invenio.search_engine_utils import get_fieldvalues
 
 if CFG_ELASTICSEARCH_LOGGING:
-    from invenio.elasticsearch_logging import register_schema
     import logging
 
-    register_schema('events.pageviews',
-        {
-            '_source': {'enabled': True},
-            'properties': {
-                'id_bibrec': {'type': 'integer'},
-                'id_user': {'type': 'integer'},
-                'client_host': {'type': 'ip'}
-            }
-        })
     _PAGEVIEW_LOG = logging.getLogger('events.pageviews')
 
 def record_exists(recID):

--- a/modules/webstat/lib/webstat_config.py
+++ b/modules/webstat/lib/webstat_config.py
@@ -43,8 +43,3 @@ if CFG_CERN_SITE:
     }
 else:
     CFG_ELASTICSEARCH_EVENTS_MAP = {}
-
-if CFG_ELASTICSEARCH_LOGGING:
-    from invenio.elasticsearch_logging import register_schema
-    for name, arguments in CFG_ELASTICSEARCH_EVENTS_MAP.items():
-        register_schema(name, arguments)


### PR DESCRIPTION
This is the code to reflect the latest Lumberjack which can log to a fallback file in case the Elasticsearch cluster goes down for some reason.
