### PR TITLE
documents: document retrieval enhancement

### DIFF
--- a/invenio/modules/documents/config.py
+++ b/invenio/modules/documents/config.py
@@ -17,13 +17,11 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""
-    invenio.modules.documents.config
-    --------------------------------
+"""Configuration options for documents."""
 
-    Defines configuration options for documents.
-"""
-from invenio.base import config
+from werkzeug.local import LocalProxy
+
+from invenio.base.globals import cfg
 
 DOCUMENTS_ENGINE = ('invenio.modules.jsonalchemy.jsonext.engines.sqlalchemy'
                     ':SQLAlchemyStorage')
@@ -36,5 +34,5 @@ DOCUMENTS_MONGODBSTORAGE = {
     'model': 'Document',
     'host': "localhost",
     'port': 27017,
-    'database': config.CFG_DATABASE_NAME,
+    'database': LocalProxy(lambda: cfg['CFG_DATABASE_NAME']),
 }

--- a/invenio/modules/documents/recordext/fields/documents.cfg
+++ b/invenio/modules/documents/recordext/fields/documents.cfg
@@ -23,7 +23,14 @@ _documents:
     Depending on the record nature this mapping could be a simple dictionary
     with `document_name: uuid`, or it could be something more complex like a list
     of dictionaries representing a TOC.
+
+    If the field is not present in the input (uploader) it will try to generate
+    it from existing Documents and BibDocFiles.
     """
+    calculated:
+        @memoize()
+        @only_if(self.get('_documents') is None)
+        _get_record_documents(self)
 
 documents:
     """Documents attached to the record.

--- a/invenio/modules/documents/recordext/functions/_get_record_documents.py
+++ b/invenio/modules/documents/recordext/functions/_get_record_documents.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+
+def _get_record_documents(record):
+    """Return list of tuples `('doc_name', 'doc_uuid')`.
+
+    If the records doesn't have any document attached to it, i.e. it was
+    uploaded using `bibupload`, looks for any existing BibDocFile and creates
+    a document with the basic information pointing to it.
+
+    If `get_record(recid, reset_cache=True)` was called it will regenerate the
+    `_documents` field out of either document or bibdocs.
+
+    :record: Record instance
+    :returns: list of tuples
+    """
+    from invenio.modules.documents import api
+    from invenio.legacy.bibdocfile.api import BibRecDocs, \
+        InvenioBibDocFileError
+
+    documents_json = api.Document.storage_engine.search(
+        {'recids': record.get('recid', -1)})
+    if documents_json.count():
+        return [(d['title'], d['uuid']) for d in documents_json]
+
+    # There are no Documents attached to the record, try BibDocFiles
+    _documents = []
+    try:
+        bibrecdocs = BibRecDocs(record.get('recid', -1))
+    except InvenioBibDocFileError:
+        return []
+    latest_files = bibrecdocs.list_latest_files()
+    for afile in latest_files:
+        document = api.Document.create(
+            dict(
+                title=afile.get_name(),
+                source=afile.get_url(),
+                uri=afile.get_full_path(),
+                description=afile.get_description(),
+                recids=[record.get('recid'), ],
+                linked=True
+            ),
+            model='record_document_base'
+        )
+        _documents.append((document['title'], document['uuid']))
+
+    return _documents

--- a/invenio/modules/jsonalchemy/jsonext/engines/mongodb_pymongo.py
+++ b/invenio/modules/jsonalchemy/jsonext/engines/mongodb_pymongo.py
@@ -34,7 +34,7 @@ class MongoDBStorage(Storage):
         self.model = model
         host = kwards.get('host', 'localhost')
         port = kwards.get('port', 27017)
-        database = kwards.get('database', 'invenio')
+        database = kwards.get('database', 'invenio').encode('utf-8')
         self.__connection = pymongo.MongoClient(host=host, port=port)
         self.__database = self.__connection[database]
         self.__collection = self.__database[model]


### PR DESCRIPTION
- When retrieving all the documents from a record looks also for the
  possible previous `BibDocFiles` in the database and creates Documents on
  the fly for them (only link).
- Fixes definition of `DOCUMENTS_MONGODBSTORAGE` so it uses the right DB
  name.
- NOTE MongoDB is required as storage engine for the documents.

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
