### PR TITLE
BibRank: no rank method fix

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_searcher.py
+++ b/modules/bibrank/lib/bibrank_citation_searcher.py
@@ -79,10 +79,10 @@ class CitationDictsDataCacher(DataCacher):
 
         def timestamp_verifier():
             citation_lastupdate = get_lastupdated('citation')
-            if citation_lastupdate:
+            try:
                 return citation_lastupdate.strftime("%Y-%m-%d %H:%M:%S")
-            else:
-                return "0000-00-00 00:00:00"
+            except AttributeError:
+                return citation_lastupdate
 
         DataCacher.__init__(self, cache_filler, timestamp_verifier)
 

--- a/modules/bibrank/lib/bibrank_tag_based_indexer.py
+++ b/modules/bibrank/lib/bibrank_tag_based_indexer.py
@@ -194,7 +194,8 @@ def get_lastupdated(rank_method_code):
     if res:
         return res[0][0]
     else:
-        raise Exception("Is this the first run? Please do a complete update.")
+        # raise Exception("Is this the first run? Please do a complete update.")
+        return "0000-00-00 00:00:00"
 
 def intoDB(dic, date, rank_method_code):
     """Insert the rank method data into the database"""
@@ -209,6 +210,8 @@ def intoDB(dic, date, rank_method_code):
 def fromDB(rank_method_code):
     """Get the data for a rank method"""
     id = run_sql("SELECT id from rnkMETHOD where name=%s", (rank_method_code, ))
+    if not id:
+        return {}
     res = run_sql("SELECT relevance_data FROM rnkMETHODDATA WHERE id_rnkMETHOD=%s", (id[0][0], ))
     if res:
         return deserialize_via_marshal(res[0][0])
@@ -394,10 +397,7 @@ def add_recIDs_by_date(rank_method_code, dates=""):
        the ranking method RANK_METHOD_CODE.
     """
     if not dates:
-        try:
-            dates = (get_lastupdated(rank_method_code), '')
-        except Exception:
-            dates = ("0000-00-00 00:00:00", '')
+        dates = (get_lastupdated(rank_method_code), '')
     if dates[0] is None:
         dates = ("0000-00-00 00:00:00", '')
     query = """SELECT b.id FROM bibrec AS b WHERE b.modification_date >= %s"""


### PR DESCRIPTION
- Fixes exception that happens when trying to get the information on a
  rank method which does not exists.

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
