### PR TITLE
BibConvert: retrieve arXiv license information

### DIFF
--- a/modules/bibconvert/etc/oaiarxiv2marcxml.xsl
+++ b/modules/bibconvert/etc/oaiarxiv2marcxml.xsl
@@ -2,7 +2,7 @@
 <!-- $Id$
 
      This file is part of Invenio.
-     Copyright (C) 2007, 2008, 2010, 2011 CERN.
+     Copyright (C) 2007, 2008, 2010, 2011, 2015 CERN.
 
      Invenio is free software; you can redistribute it and/or
      modify it under the terms of the GNU General Public License as
@@ -763,6 +763,23 @@
            <xsl:if test="./OAI-PMH:metadata/arXiv:arXiv/arXiv:comments">
               <datafield tag="500" ind1=" " ind2=" ">
                 <subfield code="a">Comments: <xsl:value-of select="normalize-space(./OAI-PMH:metadata/arXiv:arXiv/arXiv:comments)"/></subfield>
+              </datafield>
+           </xsl:if>
+
+
+           <!-- MARC FIELD 540$$a$$b$$u -->
+           <xsl:if test="./OAI-PMH:metadata/arXiv:arXiv/arXiv:license">
+              <datafield tag="540" ind1=" " ind2=" ">
+                 <subfield code="u"><xsl:value-of select="normalize-space(./OAI-PMH:metadata/arXiv:arXiv/arXiv:license)"/></subfield>
+                 <subfield code="b">arXiv</subfield>  
+                 <xsl:choose>
+                    <xsl:when test="contains(./OAI-PMH:metadata/arXiv:arXiv/arXiv:license, 'creativecommons.org/licenses/by/3.0')">
+                       <subfield code="a">CC-BY-3.0</subfield>
+                    </xsl:when>
+                    <xsl:when test="contains(./OAI-PMH:metadata/arXiv:arXiv/arXiv:license, 'creativecommons.org/licenses/by-nc-sa/3.0')">
+                       <subfield code="a">CC-BY-NC-SA-3.0</subfield>
+                    </xsl:when>
+                 </xsl:choose>
               </datafield>
            </xsl:if>
 


### PR DESCRIPTION
- Adds the license information in the 540 tag when converting
  an OAI arXiv record to MARCXML.

Signed-off-by: Ludmila Marian ludmila.marian@gmail.com
Co-authored-by: Jan Aage Lavik jan.age.lavik@cern.ch
