### PR TITLE
BibFormat: Changed the HX.bfo setting

### DIFF
--- a/modules/bibformat/etc/output_formats/HX.bfo
+++ b/modules/bibformat/etc/output_formats/HX.bfo
@@ -1,1 +1,1 @@
-default: BibTeX.bft
+default: cern_BibTex.bft


### PR DESCRIPTION
- Replaces the generic Invenio's BibTex template with a CERN one.

Signed-off-by: Sebastian Witowski sebastian.witowski@cern.ch
