### PR TITLE
WebSearch: optional Obelix integration

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -603,6 +603,17 @@ CFG_WEBSEARCH_SYNONYM_KBRS = {
     'journal': ['SEARCH-SYNONYM-JOURNAL', 'leading_to_number'],
     }
 
+# CFG_OBELIX_HOST -- optionally, enables the Obelix integration
+# and defines the Obelix IP or Hostname to connect to.
+# Searches, page views and downloads will be logged to Obelix
+# and will be used to generate recommendations recommendation data for users.
+# To integrate Obelix in the search results,
+# configure it in the BibRank settings (template_read_recommendations.cfg).
+CFG_OBELIX_HOST =
+
+# CFG_OBELIX_PREFIX -- optionally, defines the Obelix cache prefix.
+CFG_OBELIX_PREFIX = obelix::
+
 # CFG_SOLR_URL -- optionally, you may use Solr to serve full-text
 # queries and ranking.  If so, please specify the URL of your Solr instance.
 # Example: http://localhost:8983/solr (default solr port)

--- a/modules/bibdocfile/lib/bibdocfile_webinterface.py
+++ b/modules/bibdocfile/lib/bibdocfile_webinterface.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2012, 2013 CERN.
+# Copyright (C) 2012, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -68,6 +68,7 @@ from invenio.bibdocfile_managedocfiles import \
      move_uploaded_files_to_storage
 
 bibdocfile_templates = invenio.template.load('bibdocfile')
+from invenio.obelixutils import obelix, clean_user_info
 
 
 class WebInterfaceFilesPages(WebInterfaceDirectory):
@@ -163,6 +164,12 @@ class WebInterfaceFilesPages(WebInterfaceDirectory):
                     docformat += ';%s' % args['subformat']
             else:
                 docname = args['docname']
+
+            try:
+                obelix.log('download_after_search',
+                        clean_user_info(user_info), self.recid)
+            except Exception:
+                register_exception(alert_admin=True)
 
             if not docformat:
                 docformat = args['format']

--- a/modules/bibrank/etc/Makefile.am
+++ b/modules/bibrank/etc/Makefile.am
@@ -30,6 +30,7 @@ etc_DATA = bibrankgkb.cfg \
            template_download_similarity.cfg \
            template_download_total.cfg \
            template_download_users.cfg \
+           template_read_recommendations.cfg \
            template_single_tag_rank_method.cfg \
            template_word_similarity.cfg \
            template_word_similarity_solr.cfg \
@@ -56,6 +57,7 @@ EXTRA_DIST = bibrankgkb.cfg.in \
              template_download_similarity.cfg \
              template_download_total.cfg \
              template_download_users.cfg \
+             template_read_recommendations.cfg \
              template_single_tag_rank_method.cfg.in \
              template_word_similarity.cfg \
              template_word_similarity_solr.cfg \

--- a/modules/bibrank/etc/template_read_recommendations.cfg
+++ b/modules/bibrank/etc/template_read_recommendations.cfg
@@ -1,0 +1,25 @@
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+# To use with Obelix
+
+[rank_method]
+function = rrm
+
+[rrm]
+relevance_number_output_prologue = (
+relevance_number_output_epilogue = )

--- a/modules/miscutil/lib/Makefile.am
+++ b/modules/miscutil/lib/Makefile.am
@@ -102,7 +102,8 @@ pylib_DATA = __init__.py \
              hepdatautils_unit_tests.py \
              filedownloadutils.py \
              filedownloadutils_unit_tests.py \
-	     viafutils.py
+             viafutils.py \
+             obelixutils.py
 
 jsdir=$(localstatedir)/www/js
 

--- a/modules/miscutil/lib/obelixutils.py
+++ b/modules/miscutil/lib/obelixutils.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Invenio to obelix-client connector."""
+
+from invenio.config import CFG_OBELIX_HOST, CFG_OBELIX_PREFIX
+from invenio.errorlib import register_exception
+
+
+_OBELIX = None
+
+
+class ObelixNotExist(object):
+    """Empty Object, that accept everything without error."""
+
+    def __getattr__(self, name):
+        """Return always None."""
+        return lambda *args, **keyargs: None
+
+
+def get_obelix():
+    """Create or get a Obelix instance."""
+    global _OBELIX
+
+    recommendation_prefix = "recommendations::"
+
+    if CFG_OBELIX_HOST == "":
+        # Obelix is not used, so ignore all calls without error.
+        return ObelixNotExist()
+    if _OBELIX is None:
+        try:
+            import json
+            import redis
+            from obelix_client import Obelix
+            from obelix_client.storage import RedisStorage
+            from obelix_client.queue import RedisQueue
+
+            obelix_redis = redis.StrictRedis(host=CFG_OBELIX_HOST,
+                                             port=6379,
+                                             db=0)
+
+            obelix_cache = RedisStorage(obelix_redis, prefix=CFG_OBELIX_PREFIX,
+                                        encoder=json)
+
+            recommendation_storage = RedisStorage(obelix_redis,
+                                                  prefix=CFG_OBELIX_PREFIX +
+                                                  recommendation_prefix,
+                                                  encoder=json)
+
+            obelix_queue = RedisQueue(obelix_redis, prefix=CFG_OBELIX_PREFIX,
+                                      encoder=json)
+
+            _OBELIX = Obelix(obelix_cache, recommendation_storage,
+                             obelix_queue)
+        except Exception:
+            register_exception(alert_admin=True)
+            _OBELIX = None
+
+    return _OBELIX
+
+obelix = get_obelix()
+
+
+def clean_user_info(user_info):
+    """Remove all unwanted information."""
+    return {'uid': user_info.get('uid'),
+            'referer': user_info.get('referer'),
+            'uri': user_info.get('uri'),
+            'group': user_info.get('group'),
+            '': user_info.get(''),
+            }

--- a/modules/websearch/lib/websearch_webinterface.py
+++ b/modules/websearch/lib/websearch_webinterface.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -57,6 +57,7 @@ from invenio.config import \
      CFG_INSPIRE_SITE, \
      CFG_WEBSEARCH_WILDCARD_LIMIT, \
      CFG_SITE_RECORD
+
 from invenio.dbquery import Error
 from invenio.webinterface_handler import wash_urlargd, WebInterfaceDirectory
 from invenio.urlutils import redirect_to_url, make_canonical_urlargd, drop_default_urlargd
@@ -108,6 +109,7 @@ from invenio.bibmerge_webinterface import WebInterfaceMergePages
 from invenio.bibdocfile_webinterface import WebInterfaceManageDocFilesPages, WebInterfaceFilesPages
 from invenio.bibfield import get_record
 from invenio.shellutils import mymkdir
+from invenio.obelixutils import obelix, clean_user_info
 
 import invenio.template
 websearch_templates = invenio.template.load('websearch')
@@ -279,6 +281,15 @@ class WebInterfaceRecordPages(WebInterfaceDirectory):
                 navmenuid='search')
 
         from invenio.search_engine import record_exists, get_merged_recid
+
+        try:
+            obelix.log('page_view_after_search',
+                       clean_user_info(user_info),
+                       argd['recid'])
+
+        except Exception:
+            register_exception(alert_admin=True)
+
         # check if the current record has been deleted
         # and has been merged, case in which the deleted record
         # will be redirect to the new one

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ redis==2.9.0
 nydus==0.10.6
 Cerberus==0.5
 matplotlib
+git+https://github.com/inveniosoftware/obelix-client.git


### PR DESCRIPTION
- Connects Invenio with the obelix-client Python module to Obelix
- Introduces the new Obelix Recommendation System, optionally
  let users rank results by recommendations built on
  their search, view and download history
- The Obelix integration require redis to work, if the
  redis server is down or if we are unable to connect,
  Invenio will fall back to sort the records latest first
- Introduces CFG_WEBSEARCH_OBELIX_REDIS and
  CFG_WEBSEARCH_OBELIX_USER_KEY config used to set which
  redis host Invenio should connect to in order to use the
  recommendations from Obelix
- Adds bibrank config file for use with Obelix
  (template_read_recommendations.cfg)
- Fetches recommendations generated by Obelix from redis
- Logs search results to redis
- Logs page views to redis
- Logs downloads to redis

Signed-off-by: David Zerulla ddaze@outlook.de
Co-Authored-By: Fredrik Nygård Carlsen fredrik@carlsen.io
