### PR TITLE
WebSearch: tabs miss language parameter

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -4677,8 +4677,10 @@ def print_records(req, recIDs, jrec=1, rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS, f
 
                     link_ln = ''
 
-                    if ln != CFG_SITE_LANG:
-                        link_ln = '?ln=%s' % ln
+                    if 'ln' in req.form:
+                        link_ln = "?ln={0}".format(
+                            req.form.get('ln', CFG_SITE_LANG)
+                        )
 
                     recid_to_display = recid  # Record ID used to build the URL.
                     if CFG_WEBSEARCH_USE_ALEPH_SYSNOS:


### PR DESCRIPTION
- FIX Adds the proper language parameter on tabs if the user has
  selected different language from the browser preferred. (closes
  #308)

Signed-off-by: Harris Tzovanakis me@drjova.com
