### PR TITLE
WebStyle: CKEditor update

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,7 @@ MJV = 2.3
 MATHJAX = http://invenio-software.org/download/mathjax/MathJax-v$(MJV).zip
 
 # current CKeditor version
-CKV = 3.6.6
+CKV = 4.5.3
 CKEDITOR = ckeditor_$(CKV).zip
 
 # current MediaElement.js version

--- a/modules/miscutil/lib/htmlutils.py
+++ b/modules/miscutil/lib/htmlutils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013 CERN.
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -491,6 +491,10 @@ def get_html_text_editor(name, id=None, content='', textual_content=None, width=
     like replace CRLF with <br/> when editor_type equals to
     'textarea', but not when editor_type equals to 'ckeditor'.
 
+    NOTE: When you update the CKEditor, change the value of CKEDITOR.timestamp
+    and the parameter that is sent when ckeditor.js is imported to any
+    different value, to invalidate the browser cache.
+
     @param name: *str* the name attribute of the returned editor
 
     @param id: *str* the id attribute of the returned editor (when
@@ -555,7 +559,9 @@ def get_html_text_editor(name, id=None, content='', textual_content=None, width=
         /* Load the script only once, or else multiple instance of the editor on the same page will not work */
         var INVENIO_CKEDITOR_ALREADY_LOADED
             if (INVENIO_CKEDITOR_ALREADY_LOADED != 1) {
-                document.write('<script type="text/javascript" src="%(CFG_SITE_URL)s/ckeditor/ckeditor.js"><\/script>');
+                document.write('<script type="text/javascript" src="%(CFG_SITE_URL)s/ckeditor/ckeditor.js?v=2015_09_07"><\/script>');
+                /* Add custom timestamp to invalidate config files cache */
+                document.write('<script type="text/javascript">CKEDITOR.timestamp = "2015_09_07"<\/script>');
                 INVENIO_CKEDITOR_ALREADY_LOADED = 1;
             }
         //]]></script>

--- a/modules/webstyle/etc/invenio-ckeditor-config.js
+++ b/modules/webstyle/etc/invenio-ckeditor-config.js
@@ -24,7 +24,6 @@ config.toolbar_WebComment = [
                              ['HorizontalRule','Smiley','SpecialChar','ScientificChar']
 			     ];
 
-config.skin = 'v2';
 config.resize_dir = 'vertical';
 
 /* Enable browser built-in spellchecker */

--- a/modules/webstyle/etc/journal-editor-config.js
+++ b/modules/webstyle/etc/journal-editor-config.js
@@ -27,7 +27,6 @@ config.toolbar_WebJournal = [
 ['Maximize','ShowBlocks']
 ];
 
-config.skin = 'v2';
 config.resize_enabled = false;
 
 /* Remove "status" bar at the bottom of the editor displaying the DOM path*/


### PR DESCRIPTION
- BETTER Updates the CKEditor to version 4.5.3
- INCOMPATIBLE Removes the skin config variable (since there are new
  skins)

Signed-off-by: Sebastian Witowski witowski.sebastian@gmail.com
