### PR TITLE
WebSearch: improve detection of record viewers

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -358,6 +358,10 @@ def is_user_viewer_of_record(user_info, recid):
         email = email_or_group.strip().lower()
         if user_info['email'].strip().lower() == email:
             return True
+        if CFG_CERN_SITE:
+            #the egroup might be in the form egroup@cern.ch
+            if email_or_group.replace('@cern.ch', ' [CERN]') in user_info['group']:
+                return True            
     return False
 
 def check_user_can_view_record(user_info, recid):


### PR DESCRIPTION
- If CFG_CERN_SITE, consider the possibility of the viewer
  of a record being an egroup, defined as 'foo@cern.ch'
  insted of 'foo [CERN]'.

Signed-off-by: Ludmila Marian ludmila.marian@gmail.com
