### PR TITLE
BibDocFile: better exception handling on AFS error

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -1657,7 +1657,7 @@ class BibDoc(object):
         except Exception, e:
             run_sql('DELETE FROM bibdoc WHERE id=%s', (doc_id, ))
             register_exception(alert_admin=True)
-            raise InvenioBibDocFileError, e
+            raise
 
         # the object has been created: linking to bibliographical records
         doc = BibDoc(doc_id)


### PR DESCRIPTION
- If `prepare_basedir` fails to create an AFS volume instead of changing
  the nature of the exception, and probably hide it, raise the standard
  `IOError` which will be propagated up.

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
