### PR TITLE
OAIRepository: get_earliest_datestamp fix

### DIFF
--- a/modules/oairepository/lib/oai_repository_server.py
+++ b/modules/oairepository/lib/oai_repository_server.py
@@ -179,7 +179,7 @@ def get_earliest_datestamp():
     Return empty string if no records or earliest datestamp in UTC.
     """
     out = ""
-    res = run_sql("SELECT DATE_FORMAT(MIN(creation_date),'%Y-%m-%d %H:%i:%s') FROM bibrec", n=1)
+    res = run_sql("SELECT DATE_FORMAT(MIN(modification_date),'%Y-%m-%d %H:%i:%s') FROM bibrec", n=1)
     if res:
         out = localtime_to_utc(res[0][0])
     return out


### PR DESCRIPTION
* FIX Fixes get_earliest_datestamp() definition to conform to OAI-PMH
  standard: "a UTCdatetime that is the guaranteed lower limit of all
  datestamps recording changes, modifications, or deletions in the
  repository".

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>