### PR TITLE
redirect videos to cdslabs

### DIFF
--- a/modules/bibformat/lib/elements/bfe_record_url.py
+++ b/modules/bibformat/lib/elements/bfe_record_url.py
@@ -28,11 +28,20 @@ from invenio.config import \
 
 def format_element(bfo, with_ln="yes"):
     """
-    Prints the record URL.
+    Prints the record URL or the redirected URL.
+
+    If the record has 980__c:MIGRATED and a URL in 970__d (which means that
+    the record was migrated to a new system), then instead of printing the
+    URL inside the current system, we return that new URL.
 
     @param with_ln: if "yes" include "ln" attribute in the URL
     """
-    url = CFG_SITE_URL + "/" + CFG_SITE_RECORD + "/" + bfo.control_field('001')
+    url = ''
+    statuses = bfo.fields('980__c')
+    if 'MIGRATED' in statuses:
+        url = bfo.field('970__d')
+    if not url:
+        url = CFG_SITE_URL + "/" + CFG_SITE_RECORD + "/" + bfo.control_field('001')
 
     if with_ln.lower() == "yes":
         url += "?ln=" + bfo.lang

--- a/modules/websearch/lib/websearch_webinterface.py
+++ b/modules/websearch/lib/websearch_webinterface.py
@@ -310,6 +310,17 @@ class WebInterfaceRecordPages(WebInterfaceDirectory):
         elif record_status == -1:
             req.status = apache.HTTP_GONE ## The record is gone!
 
+        # Check if the current record has been migrated to another system
+        # Requires 'MIGRATED' in 980__c and 970__d with the new URL
+        recid = argd['recid']
+        statuses = get_fieldvalues(recid, '980__c')
+        if 'MIGRATED' in statuses:
+            # Redirect to the new URL (if it exists)
+            new_url = get_fieldvalues(recid, '970__d')
+            if new_url:
+                url = new_url.pop()
+                redirect_to_url(req, url)
+
         # mod_python does not like to return [] in case when of=id:
         out = perform_request_search(req, **argd)
         if isinstance(out, intbitset):


### PR DESCRIPTION
It will require adding 980__c:MIGRATED and 970__d:<url-on-cds-labs> to the migrated records.
In principle, we can already deploy it in production (it won't affect records without those 2 pieces of metadata).

Closes #1015.